### PR TITLE
Improve SSL options configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,19 +35,21 @@ wikijs_config_db_user: wikijs
 wikijs_config_db_pass: wikijsrocks
 wikijs_config_db_db: wiki
 wikijs_config_db_ssl: false
-
-wikijs_config_db_ssl_auto: true
 ```
-ONLY USED IF wikijs_config_ssl_auto si FALSE
-Uncomment the corresponding section in config.yml.j2
-Vaiables used to configure SSL connection to the database.
+
+Configuration of the SSL connection to the database.
+Ignored if `auto` is `true`.
+
 ```yml
-wikijs_config_db_ssl_rejectUnauthorized: false
-wikijs_config_db_ssl_ca: path/to/ca.crt
-wikijs_config_db_ssl_cert: path/to/cert.crt
-wikijs_config_db_ssl_key: path/to/key.pem
-wikijs_config_db_ssl_pfx: path/to/cert.pfx
-wikijs_config_db_ssl_passphrase: xyz123
+wikijs_config_ssl_options:
+  auto: true
+  # Use the fields you need when 'auto' is false.
+  # rejectUnauthorized: true
+  # ca: path/to/ca.crt
+  # cert: path/to/cert.crt
+  # key: path/to/key.pem
+  # pfx: path/to/cert.pfx
+  # passphrase: xyz123
 ```
 Only used if sqlite is selected
 ```yml

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -19,16 +19,15 @@ wikijs_config_db_pass: wikijsrocks
 wikijs_config_db_db: wiki
 wikijs_config_db_ssl: false
 
-wikijs_config_db_ssl_auto: true
-
-# ONLY USED IF wikijs_config_ssl_auto si FALSE
-# Uncomment the corresponding section in config.yml.j2
-wikijs_config_db_ssl_rejectUnauthorized: false
-wikijs_config_db_ssl_ca: path/to/ca.crt
-wikijs_config_db_ssl_cert: path/to/cert.crt
-wikijs_config_db_ssl_key: path/to/key.pem
-wikijs_config_db_ssl_pfx: path/to/cert.pfx
-wikijs_config_db_ssl_passphrase: xyz123
+wikijs_config_ssl_options:
+  auto: true
+  # Other possible fields (ONLY USED IF wikijs_config_ssl_auto is FALSE):
+  # rejectUnauthorized: true
+  # ca: path/to/ca.crt
+  # cert: path/to/cert.crt
+  # key: path/to/key.pem
+  # pfx: path/to/cert.pfx
+  # passphrase: xyz123
 
 # only used if sqlite is selected
 wikijs_config_sqlite_storage: path/to/database.sqlite

--- a/templates/config.yml.j2
+++ b/templates/config.yml.j2
@@ -32,16 +32,8 @@ db:
   ssl: {{ wikijs_config_db_ssl}}
 
   # Optional - PostgreSQL / MySQL / MariaDB only:
-  # -> Uncomment lines you need below and set `auto` to false
-  # -> Full list of accepted options: https://nodejs.org/api/tls.html#tls_tls_createsecurecontext_options
   sslOptions:
-    auto: {{ wikijs_config_db_ssl_auto }}
-    # rejectUnauthorized: {{ wikijs_config_db_ssl_rejectUnauthorized }}
-    # ca: {{ wikijs_config_db_ssl_ca }}
-    # cert: {{ wikijs_config_db_ssl_cert }}
-    # key: {{ wikijs_config_db_ssl_key }}
-    # pfx: {{ wikijs_config_db_ssl_pfx }}
-    # passphrase: {{ wikijs_config_db_ssl_passphrase }}
+    {{ wikijs_config_ssl_options | to_nice_yaml(indent=2) | indent(4, False) }}
 
   # SQLite only:
   storage: {{ wikijs_config_sqlite_storage }}


### PR DESCRIPTION
It is now possible to configure SSL options without modifying the jinja template.
Please tell me if I should change something. I am open to discussion.
Solves #1.

This is a BREAKING CHANGE.

This is a second PR that replaces PR #2, because the source branch is different.