### PR TITLE
Make wikijs run as own user

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ wikijs_version: "2.4.107"
 wikijs_download_url: "https://github.com/Requarks/wiki/releases/download/{{ wikijs_version }}/wiki-js.tar.gz"
 wikijs_download_dest: /usr/local/wikijs
 ```
+System user and group that should be created and used for the running service. wikijs_user_additional_groups allows specifying additional groups for the system user.
+```yml
+wikijs_system_user: wikijs
+wikijs_system_group: wikijs
+wikijs_user_additional_groups: ""
+```
 Port used to connect to your Wiki.js instance.
 ```yml
 wikijs_config_port: 3000

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,14 @@ wikijs_version: "2.4.107"
 wikijs_download_url: "https://github.com/Requarks/wiki/releases/download/{{ wikijs_version }}/wiki-js.tar.gz"
 wikijs_download_dest: /usr/local/wikijs
 
+############################
+# SYSTEM SPECIFIC VARIABLES
+############################
+
+wikijs_system_user: wikijs
+wikijs_system_group: wikijs
+wikijs_user_additional_groups: ""
+
 #################################
 # CONFIG FILE SPECIFIC VARIABLES
 #################################

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,10 +3,9 @@
   systemd:
     daemon_reload: true
 
-- name: Activate Wiki.js service
+- name: Enable Wiki.js service
   service:
     name: wiki
-    state: started
     enabled: true
 
 - name: Restart Wiki.js

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,19 @@
 ---
+- name: Create system group
+  group:
+    name: "{{ wikijs_system_group }}"
+    system: yes
+
+- name: Create system user
+  user:
+    name: "{{ wikijs_system_user }}"
+    group: "{{ wikijs_system_group }}"
+    groups: "{{ wikijs_user_additional_groups }}"
+    comment: "Service account for wikijs."
+    create_home: no
+    shell: /usr/sbin/nologin
+    system: yes
+
 - name: Check if Wiki.js is already installed
   stat:
     path: "{{ wikijs_download_dest }}"
@@ -14,14 +29,25 @@
     src: "{{ wikijs_download_url }}"
     remote_src: true
     dest: "{{ wikijs_download_dest }}/"
+    owner: "{{ wikijs_system_user }}"
+    group: "{{ wikijs_system_group }}"
   when: not wikijsinstalled.stat.exists or wikijs_update
+
+# Used when user or group changes
+- name: Set ownership
+  file:
+    path: "{{ wikijs_download_dest }}/"
+    owner: "{{ wikijs_system_user }}"
+    group: "{{ wikijs_system_group }}"
+    recurse: yes
+  when: wikijsinstalled.stat.pw_name != wikijs_system_user or wikijsinstalled.stat.gr_name != wikijs_system_group
 
 - name: Deploy config.yml
   template:
     src: config.yml.j2
     dest: "{{ wikijs_download_dest }}/config.yml"
-    owner: root
-    group: root
+    owner: "{{ wikijs_system_user }}"
+    group: "{{ wikijs_system_group }}"
     mode: 0640
   notify: Restart Wiki.js
 
@@ -34,7 +60,8 @@
     mode: 0640
   notify:
     - Reload systemctl daemon
-    - Activate Wiki.js service
+    - Enable Wiki.js service
+    - Restart Wiki.js
 
 - name: Flush handlers
   meta: flush_handlers

--- a/templates/wiki.service.j2
+++ b/templates/wiki.service.j2
@@ -6,8 +6,8 @@ After=network.target
 Type=simple
 ExecStart=/usr/bin/node server
 Restart=always
-# Consider creating a dedicated user for Wiki.js here:
-# User=nobody
+RestartSec=5
+User={{ wikijs_system_user }}
 Environment=NODE_ENV=production
 WorkingDirectory={{ wikijs_download_dest }}
 


### PR DESCRIPTION
Solves #4.  The role will now create a group 'wikijs', a user 'wikijs' and use them to run the service.
It also makes sure ownership is set correctly on wikijs files.
I am open to discussion if something is not ok.

No manual intervention is required.